### PR TITLE
Add multi-page site structure with shared assets and basic tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/about.html
+++ b/about.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>About - Physics In The Wild</title>
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron&display=swap" rel="stylesheet">
+  <link rel="icon" type="image/png" href="assets/favicon.png">
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+  <canvas id="bg"></canvas>
+  <header>Physics In The Wild</header>
+
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="about.html">About</a>
+    <a href="blog.html">Blog</a>
+    <a href="projects.html">Projects</a>
+    <a href="contact.html">Contact</a>
+  </nav>
+
+  <section id="about">
+    <h2>Who Am I?</h2>
+    <p> I’m Jonathan James Guevara Rodriguez, an undergraduate physics student passionate about exploring the universe’s biggest mysteries. My interests focus on experimental physics, astrophysics, and the elusive world of dark matter — the stuff we know is out there but haven’t fully uncovered.</p><br>
+    <p> I’m currently working with large astronomical datasets, tackling projects like star-galaxy classification using LSST data. I enjoy the challenge of finding structure in the noise and pulling meaningful insights from complex data.</p><br>
+    <p> As a first-generation college student and science communicator, I’m committed to making physics approachable. I believe in translating complex concepts into engaging stories and visualizations — bridging the gap between data, discovery, and public understanding while contributing to experimental research on some of the universe’s most fundamental mysteries.</p><br>
+  </section>
+
+  <footer>
+    &copy; 2025 Jonathan James Guevara Rodriguez — Physics In The Wild
+  </footer>
+
+  <script src="assets/stars.js"></script>
+</body>
+</html>

--- a/assets/stars.js
+++ b/assets/stars.js
@@ -1,0 +1,32 @@
+const canvas = document.getElementById('bg');
+const ctx = canvas.getContext('2d');
+canvas.width = window.innerWidth;
+canvas.height = window.innerHeight;
+
+let stars = [];
+for (let i = 0; i < 200; i++) {
+  stars.push({
+    x: Math.random() * canvas.width,
+    y: Math.random() * canvas.height,
+    radius: Math.random() * 1.5,
+    dx: (Math.random() - 0.5) * 0.5,
+    dy: (Math.random() - 0.5) * 0.5
+  });
+}
+
+function animate() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  ctx.fillStyle = '#a96ce0';
+  stars.forEach(star => {
+    ctx.beginPath();
+    ctx.arc(star.x, star.y, star.radius, 0, Math.PI * 2);
+    ctx.fill();
+    star.x += star.dx;
+    star.y += star.dy;
+
+    if (star.x < 0 || star.x > canvas.width) star.dx = -star.dx;
+    if (star.y < 0 || star.y > canvas.height) star.dy = -star.dy;
+  });
+  requestAnimationFrame(animate);
+}
+animate();

--- a/assets/style.css
+++ b/assets/style.css
@@ -1,0 +1,87 @@
+body, p, li {
+  font-family: 'Roboto', sans-serif;
+  font-weight: 400;
+  line-height: 1.6;
+}
+body {
+  margin: 0;
+  font-family: 'Roboto', sans-serif;
+  font-weight: 400;
+  line-height: 1.6;
+  color: #ccc;
+  background: #121212;
+  overflow-x: hidden;
+}
+header {
+  text-align: center;
+  padding: 2rem;
+  color: #a96ce0;
+  font-size: 2.5rem;
+  letter-spacing: 2px;
+}
+nav {
+  text-align: center;
+  background: #1c1c2b;
+  padding: 1rem;
+}
+nav a {
+  color: #a96ce0;
+  margin: 0 15px;
+  text-decoration: none;
+  font-weight: bold;
+}
+nav a:hover {
+  text-decoration: underline;
+}
+section {
+  padding: 2rem;
+  max-width: 900px;
+  margin: auto;
+}
+h2 {
+  color: #a96ce0;
+  border-bottom: 2px solid #a96ce0;
+  padding-bottom: 0.5rem;
+}
+a {
+  color: #a96ce0;
+  text-decoration: none;
+}
+a:hover {
+  text-decoration: underline;
+}
+footer {
+  text-align: center;
+  padding: 2rem;
+  font-size: 0.9rem;
+  color: #888;
+}
+canvas#bg {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: -1;
+  background: #121212;
+}
+.cv-button {
+  display: inline-block;
+  margin-top: 10px;
+  padding: 10px 20px;
+  background: #a96ce0;
+  color: #121212;
+  font-weight: bold;
+  border-radius: 5px;
+  text-decoration: none;
+}
+.cv-button:hover {
+  background: #8b5fc2;
+}
+#posterModal {
+  animation: fadeIn 0.3s ease-in-out;
+}
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}

--- a/blog.html
+++ b/blog.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Physics In The Wild</title>
+  <title>Blog - Physics In The Wild</title>
   <link href="https://fonts.googleapis.com/css2?family=Orbitron&display=swap" rel="stylesheet">
   <link rel="icon" type="image/png" href="assets/favicon.png">
   <link rel="stylesheet" href="assets/style.css">
@@ -20,9 +20,13 @@
     <a href="contact.html">Contact</a>
   </nav>
 
-  <section id="home">
-    <h2>Exploring the Dark Corners of the Universe</h2>
-    <p>Communicating complex physics with curiosity and creativity.</p>
+  <section id="blog">
+    <h2>Physics in the Wild — Latest Posts (Placeholders)</h2>
+    <ul>
+      <li>Why Classifying Galaxies is Harder Than You Think</li>
+      <li>Dark Matter: Hunting the Invisible</li>
+      <li>Physics in Real Life: What Makes a Bicycle Stay Up?</li>
+    </ul>
   </section>
 
   <footer>

--- a/contact.html
+++ b/contact.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Physics In The Wild</title>
+  <title>Contact - Physics In The Wild</title>
   <link href="https://fonts.googleapis.com/css2?family=Orbitron&display=swap" rel="stylesheet">
   <link rel="icon" type="image/png" href="assets/favicon.png">
   <link rel="stylesheet" href="assets/style.css">
@@ -20,9 +20,15 @@
     <a href="contact.html">Contact</a>
   </nav>
 
-  <section id="home">
-    <h2>Exploring the Dark Corners of the Universe</h2>
-    <p>Communicating complex physics with curiosity and creativity.</p>
+  <section id="contact">
+    <h2>Get in Touch</h2>
+    <p>Email: <a href="mailto:jonathan@physicsinthewild.com">jonathan@guevararodriguez.com</a></p>
+    <p>Website: <a href="https://www.JonathanJamesGuevaraRodriguez.com">JonathanJamesGuevaraRodriguez.com</a></p>
+  </section>
+  <section id="cv">
+    <h2>Curriculum Vitae</h2>
+    <p>You can download my latest CV below:</p>
+    <a href="assets/CV-Jonathan-Guevara-Rodriguez.pdf" download class="cv-button">Download My CV</a>
   </section>
 
   <footer>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "physics-in-the-wild",
+  "version": "1.0.0",
+  "description": "Static site for Physics In The Wild",
+  "scripts": {
+    "test": "node scripts/checkPages.js"
+  }
+}

--- a/projects.html
+++ b/projects.html
@@ -1,0 +1,123 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Projects - Physics In The Wild</title>
+  <link href="https://fonts.googleapis.com/css2?family=Orbitron&display=swap" rel="stylesheet">
+  <link rel="icon" type="image/png" href="assets/favicon.png">
+  <link rel="stylesheet" href="assets/style.css">
+</head>
+<body>
+  <canvas id="bg"></canvas>
+  <header>Physics In The Wild</header>
+
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="about.html">About</a>
+    <a href="blog.html">Blog</a>
+    <a href="projects.html">Projects</a>
+    <a href="contact.html">Contact</a>
+  </nav>
+
+  <section id="projects">
+    <h2>Research Projects</h2>
+  </section>
+  <section>
+    <h3>Research Assistant | nEXO (June 2025 – Present) – SLAC</h3>
+    <ul>
+      <li><strong>Objective:</strong> Research and development of a neutrino detector component for large-scale implementation in the observation of neutrinoless double beta decay.</li>
+      <li><strong>Tools:</strong> Solidworks, Fusion 360, C++, Python, MATLAB, COMSOL, SimIon</li>
+      <li><strong>Key Contributions:</strong> Collaborated with engineers and researchers to design, simulate, and prototype a charge amplification component to enhance detector efficiency.</li>
+    </ul>
+  </section>
+  <section>
+    <h3>Research Trainee | SLAC National Accelerator Lab (Summer 2024)</h3>
+    <ul>
+      <li><strong>Project:</strong> Image analysis for dark matter research using Python and Jupyter Notebook</li>
+      <li><strong>Outcome:</strong> Built scripts to process astronomical images, identify noise, and enhance detection of faint dark matter signals.</li>
+    </ul>
+  </section>
+  <section>
+    <h3>Data Science Researcher | LSSTC Data Science Fellowship (2024 – 2025)</h3>
+    <ul>
+      <li>Built a fast pipeline for star-galaxy classification using machine learning models to process LSST data.</li>
+      <li>Leveraged Python, NumPy, and Scikit-learn to improve classification accuracy for large-scale datasets.</li>
+    </ul>
+  </section>
+
+  <h2>Research Visualizations</h2>
+  <section>
+    <p>Below are examples of my analysis on Rubin LSST data:</p>
+
+    <!-- Clickable poster preview -->
+    <img id="posterPreview"
+         src="./assets/graphs/poster_preview.png"
+         alt="Preview of McNair Poster"
+         style="width:100%; max-width:700px; cursor:pointer; border-radius:8px; box-shadow: 0 4px 12px rgba(0,0,0,0.1);">
+
+    <p style="font-size: 0.9em;">Click the image to view the full research poster</p>
+
+    <!-- Modal -->
+    <div id="posterModal" style="
+         display: none;
+         position: fixed;
+         top: 0; left: 0;
+         width: 100vw; height: 100vh;
+         background: rgba(0, 0, 0, 0.9);
+         z-index: 9999;
+         justify-content: center;
+         align-items: center;
+         padding: 20px;
+         box-sizing: border-box;
+    ">
+      <!-- Close Button -->
+      <span id="closeModal" style="
+        position: absolute;
+        top: 20px;
+        right: 30px;
+        font-size: 40px;
+        color: white;
+        cursor: pointer;
+        z-index: 10000;
+      ">&times;</span>
+
+      <!-- PDF Viewer -->
+      <iframe src="./assets/graphs/McNair Poster.pdf"
+              style="
+                width: 100%;
+                height: 100%;
+                border: none;
+                border-radius: 10px;
+                background: white;
+              "></iframe>
+    </div>
+  </section>
+
+  <footer>
+    &copy; 2025 Jonathan James Guevara Rodriguez — Physics In The Wild
+  </footer>
+
+  <!-- JavaScript for Modal -->
+  <script>
+    const preview = document.getElementById('posterPreview');
+    const modal = document.getElementById('posterModal');
+    const close = document.getElementById('closeModal');
+
+    preview.onclick = () => {
+      modal.style.display = 'flex';
+    }
+
+    close.onclick = () => {
+      modal.style.display = 'none';
+    }
+
+    window.onclick = (e) => {
+      if (e.target === modal) {
+        modal.style.display = 'none';
+      }
+    }
+  </script>
+  <script src="assets/stars.js"></script>
+</body>
+</html>

--- a/scripts/checkPages.js
+++ b/scripts/checkPages.js
@@ -1,0 +1,15 @@
+const fs = require('fs');
+
+const pages = ['index.html', 'about.html', 'blog.html', 'projects.html', 'contact.html'];
+
+try {
+  pages.forEach(page => {
+    if (!fs.existsSync(page)) {
+      throw new Error(`Missing ${page}`);
+    }
+  });
+  console.log('All pages present');
+} catch (err) {
+  console.error(err.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary
- Replace single-page layout with multi-page site: home, about, blog, projects, contact
- Extract shared styling and star-field animation into reusable assets
- Add npm config and script to ensure all pages are present

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7be542e248329b6925fd50187805b