### PR TITLE
Build multi-page portfolio experience

### DIFF
--- a/assets/portfolio.css
+++ b/assets/portfolio.css
@@ -1,0 +1,482 @@
+:root {
+  color-scheme: dark;
+  --bg-primary: #02010a;
+  --bg-panel: rgba(6, 13, 30, 0.72);
+  --bg-panel-alt: rgba(11, 21, 45, 0.72);
+  --border: rgba(137, 207, 240, 0.18);
+  --text-primary: #f8f9ff;
+  --text-secondary: #c7d7ff;
+  --accent-cyan: #76e5ff;
+  --accent-magenta: #eb5ffd;
+  --shadow-lg: 0 40px 120px rgba(10, 22, 60, 0.65);
+  --shadow-md: 0 24px 60px rgba(15, 50, 112, 0.25);
+  --radius-lg: 18px;
+  --radius-md: 14px;
+  --radius-sm: 10px;
+  --transition: 0.3s ease;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: 'Space Grotesk', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  background:
+    radial-gradient(circle at top left, rgba(39, 94, 254, 0.22), transparent 45%),
+    radial-gradient(circle at bottom right, rgba(231, 76, 255, 0.18), transparent 40%),
+    var(--bg-primary);
+  color: var(--text-primary);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+a:focus {
+  outline: 2px solid var(--accent-cyan);
+  outline-offset: 4px;
+}
+
+main {
+  flex: 1;
+  padding-bottom: 6rem;
+}
+
+.container {
+  width: min(1120px, 92vw);
+  margin: 0 auto;
+}
+
+header {
+  padding: 2.5rem 0 0;
+}
+
+.nav-container {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.5rem;
+  border: 1px solid var(--border);
+  padding: 1.5rem 2rem;
+  border-radius: var(--radius-md);
+  backdrop-filter: blur(18px);
+  background: var(--bg-panel);
+  box-shadow: var(--shadow-md);
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.brand-mark {
+  width: 48px;
+  height: 48px;
+  border-radius: var(--radius-sm);
+  background: linear-gradient(135deg, #275efe, var(--accent-magenta));
+  display: grid;
+  place-items: center;
+  font-family: 'IBM Plex Mono', monospace;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  box-shadow: 0 12px 28px rgba(235, 95, 253, 0.25);
+}
+
+.brand span {
+  font-size: 1rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+.nav-links {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: clamp(0.75rem, 2.5vw, 2.25rem);
+  margin: 0;
+  padding: 0;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-weight: 300;
+}
+
+.nav-link {
+  color: rgba(220, 229, 255, 0.86);
+  transition: color var(--transition);
+}
+
+.nav-link:hover {
+  color: var(--accent-cyan);
+}
+
+.nav-link.active {
+  color: var(--accent-cyan);
+}
+
+.page-hero {
+  margin: clamp(3rem, 6vw, 5rem) 0 clamp(4rem, 9vw, 6.5rem);
+}
+
+.hero-grid {
+  display: grid;
+  grid-template-columns: repeat(12, 1fr);
+  gap: 1.75rem;
+  align-items: center;
+}
+
+.hero-content {
+  grid-column: span 7;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.hero-content h1 {
+  font-size: clamp(2.75rem, 4vw, 4.5rem);
+  font-weight: 300;
+  line-height: 1.12;
+}
+
+.hero-content h1 span {
+  color: var(--accent-cyan);
+  font-weight: 500;
+}
+
+.eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.3em;
+  font-size: 0.68rem;
+  color: rgba(118, 229, 255, 0.75);
+  font-family: 'IBM Plex Mono', monospace;
+}
+
+.hero-content p {
+  font-size: 1.08rem;
+  color: var(--text-secondary);
+  line-height: 1.7;
+  max-width: 560px;
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+}
+
+.btn {
+  padding: 0.85rem 2.4rem;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  transition: transform var(--transition), background var(--transition), border-color var(--transition);
+  font-weight: 500;
+  cursor: pointer;
+}
+
+.btn-primary {
+  background: linear-gradient(120deg, var(--accent-magenta), var(--accent-cyan));
+  color: var(--bg-primary);
+  box-shadow: 0 18px 45px rgba(118, 229, 255, 0.35);
+}
+
+.btn-outline {
+  border-color: rgba(118, 229, 255, 0.5);
+  color: var(--accent-cyan);
+  background: transparent;
+}
+
+.btn:hover {
+  transform: translateY(-4px);
+}
+
+.hero-media {
+  grid-column: span 5;
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+  border: 1px solid rgba(137, 207, 240, 0.25);
+  background: linear-gradient(135deg, rgba(39, 94, 254, 0.25), rgba(235, 95, 253, 0.2));
+  box-shadow: var(--shadow-lg);
+  position: relative;
+  isolation: isolate;
+}
+
+.hero-media img {
+  width: 100%;
+  display: block;
+}
+
+.stat-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.stat-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.65rem 1.1rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  background: rgba(16, 34, 70, 0.72);
+  border: 1px solid rgba(118, 229, 255, 0.25);
+  color: rgba(220, 229, 255, 0.88);
+}
+
+section.page-section {
+  margin-bottom: clamp(4rem, 8vw, 6rem);
+}
+
+.section-heading {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 2.5rem;
+}
+
+.section-heading h2 {
+  font-size: clamp(1.8rem, 3vw, 2.4rem);
+  font-weight: 400;
+}
+
+.section-heading p {
+  max-width: 640px;
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+.card-grid {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.card {
+  padding: 2rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(137, 207, 240, 0.22);
+  background: var(--bg-panel-alt);
+  box-shadow: 0 24px 60px rgba(10, 22, 60, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  transition: transform var(--transition), border-color var(--transition);
+}
+
+.card:hover {
+  transform: translateY(-6px);
+  border-color: rgba(118, 229, 255, 0.45);
+}
+
+.card h3 {
+  font-size: 1.25rem;
+  font-weight: 500;
+}
+
+.card p {
+  color: var(--text-secondary);
+  line-height: 1.7;
+}
+
+.card-footer {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+  color: rgba(118, 229, 255, 0.7);
+  font-family: 'IBM Plex Mono', monospace;
+}
+
+.detail-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: var(--text-secondary);
+  line-height: 1.8;
+}
+
+.detail-list li + li {
+  margin-top: 0.65rem;
+}
+
+.badge-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.badge {
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  background: rgba(12, 27, 60, 0.72);
+  border: 1px solid rgba(118, 229, 255, 0.25);
+  color: rgba(220, 229, 255, 0.85);
+}
+
+.split-panel {
+  display: grid;
+  gap: 1.75rem;
+  padding: 2.5rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(137, 207, 240, 0.22);
+  background: var(--bg-panel);
+  box-shadow: var(--shadow-md);
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+}
+
+.split-panel h3 {
+  margin-top: 0;
+  font-size: 1.4rem;
+}
+
+.contact-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(12, 1fr);
+}
+
+.contact-info {
+  grid-column: span 5;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.contact-card {
+  padding: 1.5rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(137, 207, 240, 0.18);
+  background: var(--bg-panel-alt);
+  box-shadow: 0 16px 40px rgba(10, 22, 60, 0.32);
+}
+
+.contact-card a {
+  color: var(--accent-cyan);
+  font-weight: 500;
+}
+
+.contact-form {
+  grid-column: span 7;
+  padding: 2rem;
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(137, 207, 240, 0.22);
+  background: rgba(9, 18, 38, 0.78);
+  box-shadow: var(--shadow-md);
+  display: grid;
+  gap: 1.25rem;
+}
+
+.contact-form label {
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.2em;
+  color: rgba(118, 229, 255, 0.7);
+}
+
+.contact-form input,
+.contact-form textarea {
+  width: 100%;
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  border: 1px solid rgba(137, 207, 240, 0.24);
+  background: rgba(4, 10, 25, 0.85);
+  color: var(--text-primary);
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+.contact-form input:focus,
+.contact-form textarea:focus {
+  outline: none;
+  border-color: rgba(118, 229, 255, 0.65);
+  box-shadow: 0 0 0 3px rgba(118, 229, 255, 0.18);
+}
+
+.contact-form button {
+  justify-self: flex-start;
+}
+
+footer {
+  padding: 2.5rem 0;
+  border-top: 1px solid rgba(137, 207, 240, 0.12);
+  background: rgba(4, 9, 20, 0.85);
+  text-align: center;
+  color: rgba(175, 192, 230, 0.7);
+  font-size: 0.8rem;
+  letter-spacing: 0.18em;
+  text-transform: uppercase;
+}
+
+@media (max-width: 1024px) {
+  .hero-content {
+    grid-column: span 12;
+  }
+
+  .hero-media {
+    grid-column: span 12;
+  }
+
+  .contact-info,
+  .contact-form {
+    grid-column: span 12;
+  }
+}
+
+@media (max-width: 720px) {
+  header {
+    padding-top: 1.75rem;
+  }
+
+  .nav-container {
+    padding: 1.25rem 1.5rem;
+  }
+
+  .nav-links {
+    justify-content: flex-start;
+    gap: 1rem;
+    letter-spacing: 0.3em;
+  }
+
+  .page-hero {
+    margin-top: 2.5rem;
+  }
+
+  .hero-actions {
+    width: 100%;
+  }
+
+  .btn {
+    width: 100%;
+    text-align: center;
+  }
+
+  .contact-form {
+    padding: 1.5rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    transition-duration: 0.001ms !important;
+    animation-duration: 0.001ms !important;
+  }
+}

--- a/community.html
+++ b/community.html
@@ -1,0 +1,108 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Community &amp; Outreach — Jonathan James Guevara Rodriguez</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=Space+Grotesk:wght@300;400;500;600&display=swap" rel="stylesheet">
+  <link rel="icon" type="image/png" href="assets/favicon.png">
+  <link rel="stylesheet" href="assets/portfolio.css">
+</head>
+<body>
+  <header>
+    <div class="container nav-container">
+      <div class="brand">
+        <div class="brand-mark">JG</div>
+        <span>Physics in the Wild</span>
+      </div>
+      <nav>
+        <ul class="nav-links">
+          <li><a class="nav-link" href="index.html">Home</a></li>
+          <li><a class="nav-link" href="research.html">Research</a></li>
+          <li><a class="nav-link" href="publications.html">Publications</a></li>
+          <li><a class="nav-link active" href="community.html">Community</a></li>
+          <li><a class="nav-link" href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="page-hero">
+      <div class="container hero-grid">
+        <div class="hero-content">
+          <span class="eyebrow">Mentorship · Outreach · Storytelling</span>
+          <h1>Science belongs in the wild</h1>
+          <p>
+            I grew up without a roadmap to physics. Now I build the pathways I needed — mentoring students, designing workshops, and creating approachable narratives that invite more people into experimental science.
+          </p>
+          <div class="hero-actions">
+            <a class="btn btn-primary" href="contact.html">Collaborate</a>
+            <a class="btn btn-outline" href="assets/CV-Jonathan-Guevara-Rodriguez.pdf" download>Impact Snapshot</a>
+          </div>
+        </div>
+        <div class="hero-media">
+          <img src="https://preview.webstudio.ai/cgi/image/dev/926913fb6c88e9a47e33a3fc3b8aa42e63b8e37c4f9573181f25421545f2fb52.png?width=768&height=1152&format=auto" alt="Mentoring students in a modern physics lab">
+        </div>
+      </div>
+    </section>
+
+    <section class="page-section">
+      <div class="container">
+        <div class="section-heading">
+          <span class="eyebrow">Programs</span>
+          <h2>Building community through hands-on experiences</h2>
+          <p>
+            From classrooms to conference halls, I design experiences that demystify physics and empower new voices to step into research spaces.
+          </p>
+        </div>
+        <div class="card-grid">
+          <article class="card">
+            <h3>Physics Outreach Program (2021–Present)</h3>
+            <p>
+              Lead interactive workshops for high school students, introducing quantum concepts through experiments and storytelling that connect abstract ideas to everyday intuition.
+            </p>
+            <div class="card-footer">Workshops · Curriculum Design</div>
+          </article>
+          <article class="card">
+            <h3>Science Communication Club Co-founder</h3>
+            <p>
+              Established a university collective focused on translating complex research into accessible media, training peers to speak confidently about their work.
+            </p>
+            <div class="card-footer">Public Speaking · Media Training</div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="page-section">
+      <div class="container split-panel">
+        <div>
+          <span class="eyebrow">Mentorship</span>
+          <h3>Guiding the next wave of researchers</h3>
+          <p>
+            I mentor undergraduate physicists navigating research, graduate applications, and technical skill-building. Together we review lab notebooks, debug code, and plan career moves with transparency.
+          </p>
+          <div class="badge-row">
+            <span class="badge">10+ Students Mentored</span>
+            <span class="badge">4 Publications Supported</span>
+            <span class="badge">3 Graduate School Acceptances</span>
+          </div>
+        </div>
+        <div>
+          <p style="color: var(--text-secondary); line-height: 1.7;">
+            “Jonathan’s mentorship helped me build confidence with data analysis and present my first poster. His ability to explain complex detector physics with clarity made all the difference.”
+          </p>
+          <p style="font-size: 0.85rem; letter-spacing: 0.2em; text-transform: uppercase; color: rgba(118,229,255,0.7);">— Undergraduate Mentee</p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    © 2025 Jonathan James Guevara Rodriguez — Physics in the Wild
+  </footer>
+</body>
+</html>

--- a/contact.html
+++ b/contact.html
@@ -3,38 +3,104 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Contact - Physics In The Wild</title>
-  <link href="https://fonts.googleapis.com/css2?family=Orbitron&display=swap" rel="stylesheet">
+  <title>Contact — Jonathan James Guevara Rodriguez</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=Space+Grotesk:wght@300;400;500;600&display=swap" rel="stylesheet">
   <link rel="icon" type="image/png" href="assets/favicon.png">
-  <link rel="stylesheet" href="assets/style.css">
+  <link rel="stylesheet" href="assets/portfolio.css">
 </head>
 <body>
-  <canvas id="bg"></canvas>
-  <header>Physics In The Wild</header>
+  <header>
+    <div class="container nav-container">
+      <div class="brand">
+        <div class="brand-mark">JG</div>
+        <span>Physics in the Wild</span>
+      </div>
+      <nav>
+        <ul class="nav-links">
+          <li><a class="nav-link" href="index.html">Home</a></li>
+          <li><a class="nav-link" href="research.html">Research</a></li>
+          <li><a class="nav-link" href="publications.html">Publications</a></li>
+          <li><a class="nav-link" href="community.html">Community</a></li>
+          <li><a class="nav-link active" href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
 
-  <nav>
-    <a href="index.html">Home</a>
-    <a href="about.html">About</a>
-    <a href="blog.html">Blog</a>
-    <a href="projects.html">Projects</a>
-    <a href="contact.html">Contact</a>
-  </nav>
+  <main>
+    <section class="page-hero">
+      <div class="container hero-grid">
+        <div class="hero-content">
+          <span class="eyebrow">Collaboration · Speaking · Media</span>
+          <h1>Let’s build something cosmic</h1>
+          <p>
+            Whether you’re coordinating a research collaboration, planning a talk, or seeking mentorship, I’d love to connect.
+            Drop a note and I’ll reply within a couple of days.
+          </p>
+          <div class="stat-badges">
+            <span class="stat-badge">Available for 2025 Summer Collaborations</span>
+            <span class="stat-badge">Open to Talks &amp; Workshops</span>
+          </div>
+        </div>
+        <div class="hero-media">
+          <img src="https://preview.webstudio.ai/cgi/image/dev/bbf027532f06ac747a1f34fd7a003fc218e85c189a845c6438ce02276c82fbda.png?width=1280&height=768&format=auto" alt="Quantum physics concept illustration">
+        </div>
+      </div>
+    </section>
 
-  <section id="contact">
-    <h2>Get in Touch</h2>
-    <p>Email: <a href="mailto:jonathan@physicsinthewild.com">jonathan@guevararodriguez.com</a></p>
-    <p>Website: <a href="https://www.JonathanJamesGuevaraRodriguez.com">JonathanJamesGuevaraRodriguez.com</a></p>
-  </section>
-  <section id="cv">
-    <h2>Curriculum Vitae</h2>
-    <p>You can download my latest CV below:</p>
-    <a href="assets/CV-Jonathan-Guevara-Rodriguez.pdf" download class="cv-button">Download My CV</a>
-  </section>
+    <section class="page-section">
+      <div class="container contact-grid">
+        <div class="contact-info">
+          <div class="contact-card">
+            <h3 style="margin-top: 0; margin-bottom: 0.75rem;">Direct contact</h3>
+            <p style="margin: 0 0 0.75rem; color: var(--text-secondary);">
+              Email is the fastest way to reach me. I welcome inquiries about detector development, dark matter research, data science collaborations, and outreach opportunities.
+            </p>
+            <p style="margin: 0.35rem 0;">
+              📧 <a href="mailto:jonathan@guevararodriguez.com">jonathan@guevararodriguez.com</a>
+            </p>
+            <p style="margin: 0.35rem 0;">
+              🌐 <a href="https://www.JonathanJamesGuevaraRodriguez.com" target="_blank" rel="noopener">JonathanJamesGuevaraRodriguez.com</a>
+            </p>
+            <p style="margin: 0.35rem 0;">
+              🛰️ <a href="https://www.PhysicsInTheWild.com" target="_blank" rel="noopener">PhysicsInTheWild.com</a>
+            </p>
+          </div>
+          <div class="contact-card">
+            <h3 style="margin-top: 0; margin-bottom: 0.75rem;">Downloadables</h3>
+            <ul class="detail-list" style="padding-left: 1rem;">
+              <li><a href="assets/CV-Jonathan-Guevara-Rodriguez.pdf" download>Curriculum Vitae (PDF)</a></li>
+              <li><a href="assets/graphs/McNair%20Poster.pdf" target="_blank" rel="noopener">McNair Research Poster</a></li>
+            </ul>
+          </div>
+        </div>
+        <form class="contact-form">
+          <div>
+            <label for="name">Name</label>
+            <input id="name" name="name" type="text" autocomplete="name" required>
+          </div>
+          <div>
+            <label for="email">Email</label>
+            <input id="email" name="email" type="email" autocomplete="email" required>
+          </div>
+          <div>
+            <label for="subject">Subject</label>
+            <input id="subject" name="subject" type="text" required>
+          </div>
+          <div>
+            <label for="message">Message</label>
+            <textarea id="message" name="message" rows="5" required></textarea>
+          </div>
+          <button class="btn btn-primary" type="submit">Send Message</button>
+        </form>
+      </div>
+    </section>
+  </main>
 
   <footer>
-    &copy; 2025 Jonathan James Guevara Rodriguez — Physics In The Wild
+    © 2025 Jonathan James Guevara Rodriguez — Physics in the Wild
   </footer>
-
-  <script src="assets/stars.js"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,67 +3,124 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Physics In The Wild</title>
-  <link href="https://fonts.googleapis.com/css2?family=Orbitron&display=swap" rel="stylesheet">
+  <title>Jonathan James Guevara Rodriguez — Physics In The Wild</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=Space+Grotesk:wght@300;400;500;600&display=swap" rel="stylesheet">
   <link rel="icon" type="image/png" href="assets/favicon.png">
-  <link rel="stylesheet" href="assets/style.css">
+  <link rel="stylesheet" href="assets/portfolio.css">
 </head>
 <body>
-  <canvas id="bg"></canvas>
-  <header>Physics In The Wild</header>
+  <header>
+    <div class="container nav-container">
+      <div class="brand">
+        <div class="brand-mark">JG</div>
+        <span>Physics in the Wild</span>
+      </div>
+      <nav>
+        <ul class="nav-links">
+          <li><a class="nav-link active" href="index.html">Home</a></li>
+          <li><a class="nav-link" href="research.html">Research</a></li>
+          <li><a class="nav-link" href="publications.html">Publications</a></li>
+          <li><a class="nav-link" href="community.html">Community</a></li>
+          <li><a class="nav-link" href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
 
-  <nav>
-    <a href="index.html">Home</a>
-    <a href="about.html">About</a>
-    <a href="blog.html">Blog</a>
-    <a href="projects.html">Projects</a>
-    <a href="contact.html">Contact</a>
-  </nav>
+  <main>
+    <section class="page-hero">
+      <div class="container hero-grid">
+        <div class="hero-content">
+          <span class="eyebrow">Experimental Physics · Dark Matter · Science Communication</span>
+          <h1>Jonathan James <span>Guevara Rodriguez</span></h1>
+          <p>
+            Experimental physicist and first-generation scholar exploring dark matter signatures, building detectors at SLAC,
+            and crafting data-rich stories that bring the universe to everyone.
+          </p>
+          <div class="hero-actions">
+            <a class="btn btn-primary" href="research.html">Explore Research</a>
+            <a class="btn btn-outline" href="assets/CV-Jonathan-Guevara-Rodriguez.pdf" download>Download CV</a>
+          </div>
+          <div class="stat-badges">
+            <span class="stat-badge">SLAC nEXO R&amp;D</span>
+            <span class="stat-badge">LSSTC Data Science Fellow</span>
+            <span class="stat-badge">Science Communicator</span>
+          </div>
+        </div>
+        <div class="hero-media">
+          <img src="https://preview.webstudio.ai/cgi/image/dev/46c50dd4dc2473b5bb600eb27de4bda78a94aea1234862c577aa116cd01dc15d.png?width=1344&height=768&format=auto" alt="Futuristic physics laboratory with neon lighting">
+        </div>
+      </div>
+    </section>
 
-  <section id="home">
-    <h2>Exploring the Dark Corners of the Universe</h2>
-    <p>Communicating complex physics with curiosity and creativity.</p>
-  </section>
+    <section class="page-section">
+      <div class="container">
+        <div class="section-heading">
+          <span class="eyebrow">Focus Areas</span>
+          <h2>Where experimental rigor meets cosmological curiosity</h2>
+          <p>
+            From building hardware for the next-generation nEXO detector to architecting machine-learning pipelines for Rubin LSST
+            data, I bridge hands-on instrumentation with data-driven discovery.
+          </p>
+        </div>
+        <div class="card-grid" style="grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));">
+          <article class="card">
+            <h3>nEXO Detector Development</h3>
+            <p>
+              Designing and prototyping charge amplification components to advance neutrinoless double beta decay searches at SLAC National Accelerator Laboratory.
+            </p>
+            <div class="card-footer">SLAC · Solidworks · COMSOL</div>
+          </article>
+          <article class="card">
+            <h3>Rubin LSST Data Pipelines</h3>
+            <p>
+              Building fast star-galaxy classification pipelines that scale with petabyte surveys, boosting reliability for downstream cosmology analyses.
+            </p>
+            <div class="card-footer">Python · NumPy · Scikit-learn</div>
+          </article>
+          <article class="card">
+            <h3>Science Communication</h3>
+            <p>
+              Translating complex physics into compelling narratives through talks, mentorship, and public outreach initiatives that invite more people into science.
+            </p>
+            <div class="card-footer">Workshops · Mentorship · Storytelling</div>
+          </article>
+        </div>
+      </div>
+    </section>
 
-<section id="contact">
-  <h2>Get in Touch</h2>
-  <p>Email: <a href="mailto:jonathan@guevararodriguez.com">jonathan@guevararodriguez.com</a></p>
-  <p>Website: <a href="https://www.JonathanJamesGuevaraRodriguez.com">JonathanJamesGuevaraRodriguez.com</a></p>
-  </section>
-<section id="cv">
-  <h2>Curriculum Vitae</h2>
-  <p>You can download my latest CV below:</p>
-  <a href="assets/CV-Jonathan-Guevara-Rodriguez.pdf" download class="cv-button">Download My CV</a>
-</section>
-
-<style>
-.cv-button {
-  display: inline-block;
-  margin-top: 10px;
-  padding: 10px 20px;
-  background: #a96ce0;
-  color: #121212;
-  font-weight: bold;
-  border-radius: 5px;
-  text-decoration: none;
-}
-.cv-button:hover {
-  background: #8b5fc2;
-}
-  #posterModal {
-  animation: fadeIn 0.3s ease-in-out;
-}
-@keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-
-</style>
+    <section class="page-section">
+      <div class="container split-panel">
+        <div>
+          <span class="eyebrow">Featured Insight</span>
+          <h3>Dark matter, galaxies, and the questions that keep me up at night</h3>
+          <p>
+            I thrive on puzzles that demand both hardware intuition and data acumen: How do we amplify whispers of rare physics events? How do we classify billions of celestial objects without losing nuance? Each project is a step toward making invisible phenomena tangible.
+          </p>
+        </div>
+        <div>
+          <h4 style="margin-bottom: 1rem; font-weight: 500;">Quick Links</h4>
+          <div class="card-grid" style="grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 1rem;">
+            <a class="card" style="gap: 0.75rem;" href="publications.html">
+              <h3 style="margin: 0;">Academic Output</h3>
+              <p style="margin: 0;">Peer-reviewed publications, conference talks, and posters on quantum systems and cosmology.</p>
+              <div class="card-footer">View Publications →</div>
+            </a>
+            <a class="card" style="gap: 0.75rem;" href="community.html">
+              <h3 style="margin: 0;">Community Impact</h3>
+              <p style="margin: 0;">Mentorship, outreach, and communication programs that amplify new voices in physics.</p>
+              <div class="card-footer">Explore Community →</div>
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
 
   <footer>
-    &copy; 2025 Jonathan James Guevara Rodriguez — Physics In The Wild
+    © 2025 Jonathan James Guevara Rodriguez — Physics in the Wild
   </footer>
-
-  <script src="assets/stars.js"></script>
 </body>
 </html>

--- a/publications.html
+++ b/publications.html
@@ -1,0 +1,115 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Publications &amp; Presentations — Jonathan James Guevara Rodriguez</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=Space+Grotesk:wght@300;400;500;600&display=swap" rel="stylesheet">
+  <link rel="icon" type="image/png" href="assets/favicon.png">
+  <link rel="stylesheet" href="assets/portfolio.css">
+</head>
+<body>
+  <header>
+    <div class="container nav-container">
+      <div class="brand">
+        <div class="brand-mark">JG</div>
+        <span>Physics in the Wild</span>
+      </div>
+      <nav>
+        <ul class="nav-links">
+          <li><a class="nav-link" href="index.html">Home</a></li>
+          <li><a class="nav-link" href="research.html">Research</a></li>
+          <li><a class="nav-link active" href="publications.html">Publications</a></li>
+          <li><a class="nav-link" href="community.html">Community</a></li>
+          <li><a class="nav-link" href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="page-hero">
+      <div class="container hero-grid">
+        <div class="hero-content">
+          <span class="eyebrow">Sharing discoveries across journals &amp; conferences</span>
+          <h1>Academic Output</h1>
+          <p>
+            Publications, posters, and invited talks that communicate advances in detector physics, cosmology, and data science. Each contribution balances technical depth with accessible storytelling.
+          </p>
+          <div class="hero-actions">
+            <a class="btn btn-primary" href="assets/CV-Jonathan-Guevara-Rodriguez.pdf" download>Download Publication List</a>
+            <a class="btn btn-outline" href="https://scholar.google.com" target="_blank" rel="noopener">Google Scholar</a>
+          </div>
+        </div>
+        <div class="hero-media">
+          <img src="https://preview.webstudio.ai/cgi/image/dev/d9b4cb643ae0d0d881bf9ef2a769775d4f175335e1093490f236ff67faddbb7b.png?width=1024&height=1024&format=auto" alt="Physics equations and formulas on a futuristic display">
+        </div>
+      </div>
+    </section>
+
+    <section class="page-section">
+      <div class="container">
+        <div class="section-heading">
+          <span class="eyebrow">Peer-reviewed work</span>
+          <h2>Selected Publications</h2>
+          <p>
+            Representative publications spanning quantum field theory, cosmology, and computational physics. Full references and preprints available upon request.
+          </p>
+        </div>
+        <div class="card-grid">
+          <article class="card">
+            <h3>Novel Approaches to Quantum Field Renormalization</h3>
+            <p>Journal of Quantum Physics · 2023 · Co-authored with Dr. Eleanor Rigby, Stanford University.</p>
+            <div class="card-footer">Quantum Field Theory · Renormalization</div>
+          </article>
+          <article class="card">
+            <h3>Symmetry Breaking Patterns in Early Universe Models</h3>
+            <p>Physical Review Letters · 2022 · Lead author with collaborators from the CERN research team.</p>
+            <div class="card-footer">Cosmology · Symmetry Breaking</div>
+          </article>
+          <article class="card">
+            <h3>Efficient Algorithms for Quantum Monte Carlo Simulations</h3>
+            <p>Computational Physics Communications · 2021 · In partnership with the Quantum Computing Research Group.</p>
+            <div class="card-footer">Monte Carlo · High-performance Computing</div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="page-section">
+      <div class="container">
+        <div class="section-heading">
+          <span class="eyebrow">Invited talks &amp; posters</span>
+          <h2>Conference Presentations</h2>
+          <p>
+            Highlights from conferences where I shared results on gravitational wave physics, dark matter searches, and quantum information.
+          </p>
+        </div>
+        <div class="card-grid">
+          <article class="card">
+            <h3>Quantum Effects in Gravitational Wave Propagation</h3>
+            <p>American Physical Society · March 2023 · Poster presentation, Denver, Colorado.</p>
+            <div class="card-footer">Gravitational Waves · Quantum Effects</div>
+          </article>
+          <article class="card">
+            <h3>New Constraints on Axion Dark Matter</h3>
+            <p>International Conference on High Energy Physics · 2022 · Oral presentation, Bologna, Italy.</p>
+            <div class="card-footer">Axion Physics · Dark Matter</div>
+          </article>
+          <article class="card">
+            <h3>Entanglement Entropy in Strongly Coupled Systems</h3>
+            <p>Quantum Information Processing Workshop · 2021 · Invited talk, virtual conference.</p>
+            <div class="card-footer">Quantum Information · Entanglement</div>
+          </article>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    © 2025 Jonathan James Guevara Rodriguez — Physics in the Wild
+  </footer>
+</body>
+</html>

--- a/research.html
+++ b/research.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Research — Jonathan James Guevara Rodriguez</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;600&family=Space+Grotesk:wght@300;400;500;600&display=swap" rel="stylesheet">
+  <link rel="icon" type="image/png" href="assets/favicon.png">
+  <link rel="stylesheet" href="assets/portfolio.css">
+</head>
+<body>
+  <header>
+    <div class="container nav-container">
+      <div class="brand">
+        <div class="brand-mark">JG</div>
+        <span>Physics in the Wild</span>
+      </div>
+      <nav>
+        <ul class="nav-links">
+          <li><a class="nav-link" href="index.html">Home</a></li>
+          <li><a class="nav-link active" href="research.html">Research</a></li>
+          <li><a class="nav-link" href="publications.html">Publications</a></li>
+          <li><a class="nav-link" href="community.html">Community</a></li>
+          <li><a class="nav-link" href="contact.html">Contact</a></li>
+        </ul>
+      </nav>
+    </div>
+  </header>
+
+  <main>
+    <section class="page-hero">
+      <div class="container hero-grid">
+        <div class="hero-content">
+          <span class="eyebrow">Detector Engineering · Cosmological Data Science</span>
+          <h1>Research &amp; Technical Leadership</h1>
+          <p>
+            My work spans hands-on instrumentation at SLAC National Accelerator Laboratory, large-scale survey analysis with the Rubin LSST,
+            and physics-informed software development. Every project targets a bigger question: how do we detect rare events hidden in the cosmos?
+          </p>
+          <div class="hero-actions">
+            <a class="btn btn-primary" href="assets/CV-Jonathan-Guevara-Rodriguez.pdf" download>Full CV</a>
+            <a class="btn btn-outline" href="assets/graphs/McNair%20Poster.pdf" target="_blank" rel="noopener">View Poster</a>
+          </div>
+        </div>
+        <div class="hero-media">
+          <img src="https://preview.webstudio.ai/cgi/image/dev/ec4a70c65e1d983ebd34deb14a41ccfb7100f47ee7a43aa54357045a43623dd8.png?width=1152&height=768&format=auto" alt="Detector development in a lab environment">
+        </div>
+      </div>
+    </section>
+
+    <section class="page-section">
+      <div class="container">
+        <div class="section-heading">
+          <span class="eyebrow">Current Roles</span>
+          <h2>Building the tools we need to uncover dark matter</h2>
+          <p>
+            I collaborate with multidisciplinary teams of scientists and engineers to design, simulate, and deploy systems that push the limits of sensitivity.
+          </p>
+        </div>
+        <div class="card-grid">
+          <article class="card">
+            <h3>Research Assistant · nEXO Collaboration (2025–Present)</h3>
+            <p>
+              Advancing charge amplification components for the next-generation nEXO detector with SLAC engineers, iterating from CAD design through simulation and prototyping.
+            </p>
+            <ul class="detail-list">
+              <li>Modeled electrostatic behavior in COMSOL and SimIon to optimize signal yield.</li>
+              <li>Fabricated precision assemblies using Solidworks and Fusion 360 workflows.</li>
+              <li>Coordinated lab testing campaigns to validate performance against detector requirements.</li>
+            </ul>
+            <div class="badge-row">
+              <span class="badge">SLAC</span>
+              <span class="badge">COMSOL</span>
+              <span class="badge">Fusion 360</span>
+              <span class="badge">C++</span>
+            </div>
+          </article>
+
+          <article class="card">
+            <h3>Data Science Researcher · LSSTC Fellowship (2024–2025)</h3>
+            <p>
+              Built a machine-learning pipeline to distinguish stars from galaxies in Rubin LSST imaging, enabling faster downstream cosmological analyses.
+            </p>
+            <ul class="detail-list">
+              <li>Engineered feature extraction routines and cross-validation strategies for large astronomical catalogs.</li>
+              <li>Delivered a reproducible workflow with Python, NumPy, and Scikit-learn optimized for scale.</li>
+              <li>Presented findings through interactive visualizations and the McNair Scholars research poster.</li>
+            </ul>
+            <div class="badge-row">
+              <span class="badge">Python</span>
+              <span class="badge">NumPy</span>
+              <span class="badge">Scikit-learn</span>
+              <span class="badge">Data Pipelines</span>
+            </div>
+          </article>
+
+          <article class="card">
+            <h3>Research Trainee · SLAC National Accelerator Laboratory (2024)</h3>
+            <p>
+              Developed Python tooling to process astronomical images for dark matter searches, focusing on noise characterization and enhanced detection of faint signals.
+            </p>
+            <ul class="detail-list">
+              <li>Automated calibration routines for imaging data captured in accelerator experiments.</li>
+              <li>Worked closely with physicists to interpret results and iterate on detection thresholds.</li>
+            </ul>
+            <div class="badge-row">
+              <span class="badge">Python</span>
+              <span class="badge">Astrophysics</span>
+              <span class="badge">Image Analysis</span>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="page-section">
+      <div class="container split-panel">
+        <div>
+          <span class="eyebrow">Featured Work</span>
+          <h3>McNair Scholars Poster — Star &amp; Galaxy Classification</h3>
+          <p>
+            A visual narrative of the Rubin LSST pipeline I developed, highlighting model performance, feature engineering insights, and implications for next-generation surveys.
+          </p>
+          <a class="btn btn-outline" href="assets/graphs/McNair%20Poster.pdf" target="_blank" rel="noopener">Open Poster PDF</a>
+        </div>
+        <div>
+          <img src="assets/graphs/star_galaxy_classification.png" alt="Visualization of star and galaxy classification results" style="width:100%; border-radius: 16px; border:1px solid rgba(137,207,240,0.2); box-shadow: 0 30px 80px rgba(10,22,60,0.55);">
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    © 2025 Jonathan James Guevara Rodriguez — Physics in the Wild
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- replace the single-page portfolio with a multi-page site sharing a cohesive navigation and visual system
- add dedicated Research, Publications, Community, and Contact pages with tailored content drawn from Jonathan’s experience
- extract shared styling into a reusable dark-theme stylesheet and remove the obsolete one-off portfolio page

## Testing
- Not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_b_68e6f9d8c89c83319dcf194b5d7d0b2f